### PR TITLE
Move .json files to share folder

### DIFF
--- a/forallpeople/environment.py
+++ b/forallpeople/environment.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-import os
-from collections import ChainMap
+
 import pathlib
 import json
 import re

--- a/forallpeople/environment.py
+++ b/forallpeople/environment.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-
-
+import os
 from collections import ChainMap
 import pathlib
 import json
@@ -117,8 +116,10 @@ class Environment:
     def _load_environment(self, env_name: str):
         """
         Returns a dict that describes a set of unit definitions as contained in the
-        JSON file titled "'env_name'.json" after the 'Dimension' definition is converted to
-        an Dimensions object and any factors are checked for safety then evaluated.
+        JSON file titled "'env_name'.json". Alternatively, 'env_name' can
+        also be a path to a JSON file outside forallpeople.
+        After the 'Dimension' definition is converted to an Dimensions
+        object and any factors are checked for safety then evaluated.
         Raises error if file not found.
         """
         dim_array_not_defn = (
@@ -130,10 +131,13 @@ class Environment:
             "must be an arithmetic expr (as a str), a float,"
             "or an int: not '{factor}'."
         )
+        if pathlib.Path(env_name).exists():
+            file_path = pathlib.Path(env_name)
+        else:
+            path = pathlib.Path(__file__).parent
+            filename = env_name + ".json"
+            file_path = path / filename
 
-        path = pathlib.Path(__file__).parent
-        filename = env_name + ".json"
-        file_path = path / filename
         with open(file_path, "r", encoding="utf-8") as json_unit_definitions:
             units_environment = json.load(json_unit_definitions)
 


### PR DESCRIPTION
Hi Connor,

I went ahead and made some changes;
- Moved all .json files to environment/share/forallpeople
- Updated si_environment.py and environment.py (is one of them outdated? why do you need two?) to find the new .json path.

I tested loading the default environment using an installed pip package with these updates, and that all worked fine. 

Kind regards, 
Jim