### PR TITLE
Various Fixes

### DIFF
--- a/forallpeople/__init__.py
+++ b/forallpeople/__init__.py
@@ -32,7 +32,7 @@ A module to model the seven SI base units:
 #    limitations under the License.
 from __future__ import annotations
 
-__version__ = "2.6.4"
+__version__ = "2.6.5"
 
 from fractions import Fraction
 from typing import Union, Optional
@@ -90,7 +90,7 @@ class Physical(object):
             raise AttributeError(
                 "Cannot set a prefix on a Physical if it has a factor."
             )
-        # check if elligible for prefixing; do not rely on __repr__ to ignore it
+        # check if eligible for prefixing; do not rely on __repr__ to ignore it
         return Physical(
             self.value, self.dimensions, self.factor, self.precision, prefixed
         )
@@ -98,12 +98,12 @@ class Physical(object):
     @property
     def repr(self) -> str:
         """
-        Returns a repr that can be used to create another Physical instance.
+        Returns a traditional Python string representation of the Physical instance.
         """
-        repr_str = "Physical(value={}, dimensions={}, factor={:.5}, precision={}, _prefixed={})"
+        repr_str = "Physical(value={}, dimensions={}, factor={:.5}, precision={}, prefixed={})"
         factor = float(self.factor)
         if self.factor == 1:
-            repr_str = "Physical(value={}, dimensions={}, factor={}, precision={}, _prefixed={})"
+            repr_str = "Physical(value={}, dimensions={}, factor={}, precision={}, prefixed={})"
             factor = 1
         return repr_str.format(
             self.value, self.dimensions, factor, self.precision, self.prefixed
@@ -114,10 +114,11 @@ class Physical(object):
         Returns a new Physical with a new precision, 'n'. Precision controls
         the number of decimal places displayed in repr and str.
         """
-        raise PendingDeprecationWarning(
+        warnings.warn(
             "Using .round() is going to be deprecated. "
-            "Use Python's built-in round() function instead."
+            "Use Python's built-in round() function instead.", DeprecationWarning
         )
+        return round(self, n)
 
     def split(self, base_value: bool = True) -> tuple:
         """
@@ -147,8 +148,10 @@ class Physical(object):
 
     def to(self, unit_name="") -> Optional[Physical]:
         """
-        Returns None and alters the instance into one of the eligible
-        alternative units for its dimension, if it exists in the alternative_units dict;
+        Returns a Physical instance representing self converted into one of the available
+        conversion units for its dimension.
+        If .to() is called without any arguments, then it will return None and instead
+        print a list of available conversion units.
         """
         dims = self.dimensions
         env_dims = environment.units_by_dimension

--- a/forallpeople/physical_helper_functions.py
+++ b/forallpeople/physical_helper_functions.py
@@ -136,7 +136,7 @@ def _get_units_by_factor(
     """
     ## TODO Write a pow() to handle fractions and rationals
     new_factor = fraction_pow(factor, -Fraction(1 / power))
-    units_match = units_env().get(new_factor, dict())
+    units_match = _match_factors(new_factor, units_env())
     try:
         units_name = tuple(units_match.keys())[0]
     except IndexError:
@@ -145,6 +145,20 @@ def _get_units_by_factor(
     if dims != retrieved_dims:
         return dict()
     return units_match
+
+
+def _match_factors(new_factor: Fraction, units_env: dict, tol=Fraction(1, int(1e9))) -> Union[Fraction, dict]:
+    """
+    Returns 
+    """
+    units_match = units_env.get(new_factor, dict())
+    if units_match != dict():
+        return units_match
+    else:
+        for factor, units in units_env.items():
+            if abs(new_factor - factor) < tol:
+                return units
+        return dict()
 
 
 def _get_derived_unit(dims: Dimensions, units_env: dict) -> dict:

--- a/forallpeople/tests/test_forallpeople.py
+++ b/forallpeople/tests/test_forallpeople.py
@@ -170,13 +170,13 @@ def test_repr():
         MPa.repr
         == "Physical(value=1000000.0, dimensions="
         + "Dimensions(kg=1, m=-1, s=-2, A=0, cd=0, K=0, mol=0), "
-        + "factor=1, precision=3, _prefixed=)"
+        + "factor=1, precision=3, prefixed=)"
     )
     assert (
         ft.repr
         == "Physical(value=0.3048, dimensions="
         + "Dimensions(kg=0, m=1, s=0, A=0, cd=0, K=0, mol=0), "
-        + "factor=3.2808, precision=3, _prefixed=)"
+        + "factor=3.2808, precision=3, prefixed=)"
     )
 
 
@@ -190,8 +190,8 @@ def test_prefixed():
 
 
 def test_round():
-    with pytest.raises(PendingDeprecationWarning):
-        assert repr((25.2398783 * N).round(4)) == "25.2399 N"
+    # with pytest.raises(DeprecationWarning):
+    #     assert repr((25.2398783 * N).round(4)) == "25.2399 N"
     assert repr(round((25.2398783 * N), 4)) == "25.2399 N"
 
 
@@ -516,7 +516,7 @@ def test_defined_unit_persistence():
     assert repr(b) == "25.000 kip⁻²"
     assert (
         b.repr
-        == "Physical(value=1.2634765224402213e-06, dimensions=Dimensions(kg=-2, m=-2, s=4, A=0, cd=0, K=0, mol=0), factor=1.9787e+07, precision=3, _prefixed=)"
+        == "Physical(value=1.2634765224402213e-06, dimensions=Dimensions(kg=-2, m=-2, s=4, A=0, cd=0, K=0, mol=0), factor=1.9787e+07, precision=3, prefixed=)"
     )
     assert repr(c) == "0.072 ksf"
     assert repr(g) == "1653.380 lb"


### PR DESCRIPTION
## FIXES:

* Doc string on `.to()` was incorrect (#74)
* Added tolerance check to factor look-up (#73, #63)
* Error raised when using `.to()` with a unit name that was not available (#72)
* `.repr` is now consistent with attribute names (#71)