### PR TITLE
fix: equality throws exception when units are not the same

### DIFF
--- a/forallpeople/__init__.py
+++ b/forallpeople/__init__.py
@@ -363,9 +363,7 @@ class Physical(object):
         elif isinstance(other, Physical) and self.dimensions == other.dimensions:
             return math.isclose(self.value, other.value)
         else:
-            raise ValueError(
-                "Can only compare between Physical instances of equal dimension."
-            )
+            return False
 
     def __gt__(self, other):
         if isinstance(other, NUMBER):

--- a/forallpeople/tests/test_forallpeople.py
+++ b/forallpeople/tests/test_forallpeople.py
@@ -387,9 +387,8 @@ def test___eq__():
     assert N == 1
     assert Pa == 1
     assert kg == 1
-    with pytest.raises(ValueError):
-        kg == m
-        N == Pa
+    assert kg != m
+    assert N != Pa
 
 
 def test___gt__():


### PR DESCRIPTION
Closes https://github.com/connorferster/forallpeople/issues/119. 