### PR TITLE
fix: make factor index accumulate and resolve collisions by dimension

### DIFF
--- a/forallpeople/environment.py
+++ b/forallpeople/environment.py
@@ -105,7 +105,14 @@ class Environment:
                 self._units_by_dimension["defined"].setdefault(
                     dimension, dict()
                 ).update({name: definition})
-                self._units_by_factor.update({factor: {name: definition}})
+                # Accumulate rather than overwrite: multiple units can share
+                # the same factor value with different dimensions (e.g. kN and
+                # mT both have factor 0.001).  Overwriting silently discards
+                # all but the last-loaded unit from the factor index.
+                if factor in self._units_by_factor:
+                    self._units_by_factor[factor][name] = definition
+                else:
+                    self._units_by_factor[factor] = {name: definition}
         self.push_module = push_module  # Update previous push_module; could be either module or top-level
 
     def _push_vars(self, units_dict: dict, module: ModuleType) -> None:

--- a/forallpeople/environments/test_definitions.json
+++ b/forallpeople/environments/test_definitions.json
@@ -58,6 +58,11 @@
     "Symbol": "lb",
     "Default": true
 },
+"test_collision_unit": {
+    "Dimension": [1,0,-2,0,0,0,0],
+    "Factor": "1/0.45359237/9.80665",
+    "Symbol": "tcu"
+},
 "lb_ft": {
     "Dimension": [1,0,-2,0,0,0,0],
     "Factor": "0.3048/0.45359237/9.80665",

--- a/forallpeople/physical_helper_functions.py
+++ b/forallpeople/physical_helper_functions.py
@@ -145,22 +145,21 @@ def _get_units_by_factor(
     factor: float, dims: Dimensions, units_env: Callable, power: Union[int, float]
 ) -> dict:
     """
-    Returns a units_dict from the environment instance if the numerical
-    value of 'factor' is a match for a derived unit defined in the
-    environment instance and the dimensions stored in the units_dict are
-    equal to 'dims'. Returns an empty dict, otherwise.
+    Returns a single-entry dict ``{name: definition}`` from the environment
+    factor index when *factor* (raised to *1/power*) matches a key in that
+    index **and** the matched entry's Dimension equals *dims*.
+    Returns an empty dict when no match exists.
+
+    A factor key may map to multiple unit definitions (e.g. kN and mT both
+    have factor 0.001).  The function iterates all candidates and returns
+    only the one whose Dimension matches the queried *dims*.
     """
-    ## TODO Write a pow() to handle fractions and rationals
     new_factor = fraction_pow(factor, -Fraction(1 / power))
     units_match = _match_factors(new_factor, units_env())
-    try:
-        units_name = tuple(units_match.keys())[0]
-    except IndexError:
-        units_name = ""
-    retrieved_dims = units_match.get(units_name, dict()).get("Dimension", dict())
-    if dims != retrieved_dims:
-        return dict()
-    return units_match
+    for name, defn in units_match.items():
+        if dims == defn.get("Dimension"):
+            return {name: defn}
+    return dict()
 
 
 def _match_factors(

--- a/forallpeople/tests/test_fix_factor_index_collision.py
+++ b/forallpeople/tests/test_fix_factor_index_collision.py
@@ -1,0 +1,122 @@
+"""
+Focused regression tests for the factor-index collision fix
+(branch: fix_factor_index_collision).
+
+These tests exercise only the behaviour changed on this branch:
+
+  * environment.Environment builds ``_units_by_factor`` by *accumulating*
+    every unit that shares a numeric Factor, instead of overwriting so that
+    only the last-loaded unit survives.
+  * physical_helper_functions._get_units_by_factor resolves a factor key to
+    the single candidate whose Dimension matches the queried dims, rather
+    than blindly inspecting the first candidate.
+
+The ``test_definitions`` environment contains a deliberate collision:
+``lb`` (Dimension [1,1,-2], a force) and ``test_collision_unit`` (Dimension
+[1,0,-2], a force-per-length) share the identical Factor
+``1/0.45359237/9.80665``.
+"""
+
+from fractions import Fraction
+
+import forallpeople as si
+import forallpeople.physical_helper_functions as phf
+
+# Push the test environment to the top level so the unit names (lb, ft, ...)
+# and the internal factor index are available for these tests.
+si.environment("test_definitions", top_level=True)
+
+env_fact = si.environment.units_by_factor
+
+# Dimension vectors used throughout.
+FORCE_DIMS = si.Dimensions(1, 1, -2, 0, 0, 0, 0)          # lb
+SPRING_DIMS = si.Dimensions(1, 0, -2, 0, 0, 0, 0)         # test_collision_unit
+LENGTH_DIMS = si.Dimensions(0, 1, 0, 0, 0, 0, 0)          # no factor match
+
+# lb and test_collision_unit are defined with the identical Factor string.
+SHARED_FACTOR = Fraction(1) / Fraction("0.45359237") / Fraction("9.80665")
+
+
+# ---------------------------------------------------------------------------
+# environment.py — factor index accumulation
+# ---------------------------------------------------------------------------
+
+def test_factor_index_accumulates_units_with_shared_factor():
+    """Both units that share a Factor must coexist under the same key in
+    _units_by_factor; neither may silently overwrite the other."""
+    bucket = env_fact().get(lb.factor, {})  # noqa: F821 - injected by environment
+    assert "lb" in bucket
+    assert "test_collision_unit" in bucket
+
+
+def test_factor_index_key_matches_shared_factor_value():
+    """The collision bucket is stored under the shared numeric factor."""
+    assert lb.factor == SHARED_FACTOR  # noqa: F821 - injected by environment
+    assert SHARED_FACTOR in env_fact()
+
+
+def test_factor_index_preserves_distinct_definitions():
+    """Accumulation must keep each definition intact (correct Dimension and
+    Symbol), not merge or clobber their contents."""
+    bucket = env_fact().get(SHARED_FACTOR, {})
+    assert bucket["lb"]["Dimension"] == FORCE_DIMS
+    assert bucket["test_collision_unit"]["Dimension"] == SPRING_DIMS
+    assert bucket["test_collision_unit"]["Symbol"] == "tcu"
+
+
+# ---------------------------------------------------------------------------
+# physical_helper_functions.py — dimension-aware factor lookup
+# ---------------------------------------------------------------------------
+
+def test_get_units_by_factor_picks_force_on_collision():
+    """Querying the shared factor with force dims returns lb, not the
+    force-per-length collision unit."""
+    result = phf._get_units_by_factor(lb.factor, FORCE_DIMS, env_fact, 1)  # noqa: F821
+    assert "lb" in result
+    assert "test_collision_unit" not in result
+
+
+def test_get_units_by_factor_picks_spring_on_collision():
+    """Querying the shared factor with force-per-length dims returns the
+    collision unit, not lb."""
+    result = phf._get_units_by_factor(lb.factor, SPRING_DIMS, env_fact, 1)  # noqa: F821
+    assert "test_collision_unit" in result
+    assert "lb" not in result
+
+
+def test_get_units_by_factor_returns_single_entry_on_collision():
+    """The lookup narrows a multi-candidate bucket down to exactly one unit."""
+    result = phf._get_units_by_factor(lb.factor, SPRING_DIMS, env_fact, 1)  # noqa: F821
+    assert len(result) == 1
+
+
+def test_get_units_by_factor_returns_empty_when_no_dimension_match():
+    """A factor that matches the bucket but no candidate's Dimension yields
+    an empty dict — accumulation must not create false positives."""
+    result = phf._get_units_by_factor(lb.factor, LENGTH_DIMS, env_fact, 1)  # noqa: F821
+    assert result == {}
+
+
+def test_get_units_by_factor_returns_empty_when_factor_unknown():
+    """A factor with no bucket at all still resolves to an empty dict."""
+    unknown_factor = 1234.5678
+    result = phf._get_units_by_factor(unknown_factor, FORCE_DIMS, env_fact, 1)
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: repr resolves the correct unit despite the collision
+# ---------------------------------------------------------------------------
+
+def test_repr_resolves_force_unit_despite_collision():
+    """An lb-dimensioned quantity still renders as lb even though another
+    unit shares its factor."""
+    quantity = 10 * lb  # noqa: F821 - injected by environment
+    assert "lb" in repr(quantity)
+
+
+def test_repr_resolves_collision_unit_despite_shared_factor():
+    """A force-per-length quantity built from the collision unit renders with
+    its own symbol, proving the correct branch of the factor index is used."""
+    quantity = 10 * test_collision_unit  # noqa: F821 - injected by environment
+    assert "tcu" in repr(quantity)


### PR DESCRIPTION
Inside the environment, units are stored in a lookup table keyed by their numeric Factor. Some units have the same factor but different dimensions (for example kN and mT are both 0.001). The old code overwrote the table entry each time, so only the last unit with a given factor was kept. Looking up any of the others gave back the wrong unit, or nothing. For non-colliding units the lookup still returns the same single result as before, so existing code and tests are unaffected.

_Changes made_

`environment.py`: instead of replacing the entry, it now adds each unit into the bucket for that factor. All units that share a factor are kept.
`physical_helper_functions.py`: _get_units_by_factor now looks through every unit in the bucket and returns the one whose dimension matches what was asked for, and returns nothing if none match. Before, it only checked the first one.
environments/test_definitions.json: added test_collision_unit, same factor as lb but a different dimension, so the tests can trigger a collision.
`tests/test_fix_factor_index_collision.py` (new): tests for this behaviour.